### PR TITLE
Don't use `reverse_merge`

### DIFF
--- a/lib/idmclient.rb
+++ b/lib/idmclient.rb
@@ -22,11 +22,12 @@ class IDMClient
 
   def initialize(uri, options=Hash.new)
     # Set defaults
-    options.reverse_merge!({
+    default_options = {
       :ca_file => '/etc/ipa/ca.crt',
       :api_version => '2.228',
       :debug => false
-    })
+    }
+    options = default_options.merge(options)
     @uri_base = uri
     @uri_auth = URI("#{uri_base}/session/login_password")
     @uri_data = URI("#{uri_base}/session/json")


### PR DESCRIPTION
`reverse_merge` is part of rails I think.  Instead of making that a
dependency, it's probably easier to just get rid of the requirement by
refactoring to use standard `merge`.

Fixes GH-1